### PR TITLE
VM local retain stack

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -197,6 +197,7 @@ struct svm {
     varray_value globals; /** Global variables */
     varray_value tlvars; /** Thread-local variables */
     varray_value stack; /** The stack */
+    varray_value retain; /** List of values to retain across GC */
     callframe frame[MORPHO_CALLFRAMESTACKSIZE]; /** The call frame stack */
     errorhandler errorhandlers[MORPHO_ERRORHANDLERSTACKSIZE]; /** Error handler stack */
 

--- a/src/core/gc.c
+++ b/src/core/gc.c
@@ -158,6 +158,13 @@ void vm_gcmarkroots(vm *v) {
     }
 
 #ifdef MORPHO_DEBUG_LOGGARBAGECOLLECTOR
+    morpho_printf(v, "> Retain list.\n");
+#endif
+    for (int i=0; i<v->retain.count; i++) {
+        vm_gcmarkvalue(v, v->retain.data[i]);
+    }
+    
+#ifdef MORPHO_DEBUG_LOGGARBAGECOLLECTOR
     morpho_printf(v, "> Thread local storage.\n");
 #endif
     for (int i=0; i<v->tlvars.count; i++) {


### PR DESCRIPTION
This is now used by bindobjects. Fixes a race condition in parallel code.